### PR TITLE
1.手机号匹配正则增加16开头手机号、2.第一次输入手机登录时会失败

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,27 @@
 {
-    "liveServer.settings.port": 5501
+    "liveServer.settings.port": 5501,
+    "kunpeng.remote.ssh.machineinfo": [],
+    "editor.tokenColorCustomizations": {
+        "textMateRules": [
+            {
+                "scope": "kunpeng.func",
+                "settings": {
+                    "foreground": "#28a745"
+                }
+            },
+            {
+                "scope": "kunpeng.intrinsics",
+                "settings": {
+                    "foreground": "#28a745"
+                }
+            },
+            {
+                "scope": "kunpeng.builtIn",
+                "settings": {
+                    "foreground": "#28a745"
+                }
+            }
+        ]
+    },
+    "kunpeng.remote.ssh.clientpath": "C:\\Windows\\System32\\OpenSSH\\ssh.exe"
 }

--- a/main.js
+++ b/main.js
@@ -243,11 +243,11 @@ async function initConfig(){
     document.getElementById('getCaptcha').onclick = async function(e){
         let phone = document.getElementById('phone');  
         // 校验手机号格式 
-        var regExp = new RegExp("^1[3578]\\d{9}$");
+        var regExp = new RegExp("^1[35678]\\d{9}$");
         if(phone.value != "" && regExp.test(phone.value)){       
             let second = 30;
             // 发送验证码
-            let resp = await musicServer.sendCaptcha(config.phone);
+            let resp = await musicServer.sendCaptcha(config.phone?config.phone:phone.value);
             if(resp.code == 200){
                 // 若发送成功，则保存手机号到配置项和本地存储中
                 config.phone = phone.value;


### PR DESCRIPTION
失败原因为出现config.phone中为null，第一次需要注入config.phone，可是登录接口使用的参数却也是这里，也就是第一次使用这个页面的人不可能登录成功，改为三目运算如果config.phone为null使用phone.value，不过最好还是把页面表单的phone.value和config.phone关联